### PR TITLE
fix: ajax redirect login

### DIFF
--- a/src/others.js
+++ b/src/others.js
@@ -19,7 +19,7 @@ export const getCookie = (cookie, name) => {
 export const ajax = (options, isOriginal = false, configure) => {
     $.support.cors = true;
     const config = $.extend({}, {
-        LOGIN_URL: '/accounts/login',
+        LOGIN_URL: '/web/accounts/login',
     }, configure);
 
     const defaultOptions = {


### PR DESCRIPTION
ajax 401 403跳转到 /accounts/login时，会丢失?next, 

跳转到/web/accounts/login


node端需要校验next的值是否来自shanbay