### PR TITLE
replaced array.find with ie9 compatible filter()[0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ jspm_packages
 # Optional REPL history
 .node_repl_history
 .vscode
+.idea
+

--- a/src/others.js
+++ b/src/others.js
@@ -16,7 +16,7 @@ export const getCookie = (cookie, cname) => {
     const name = `${cname}=`;
     const decodedCookie = decodeURIComponent(document.cookie);
     const ca = decodedCookie.split(';');
-    const result = ca.find(el => el.indexOf(name) > -1);
+    const result = ca.filter(el => el.indexOf(name) > -1)[0];
     return result && result.substring((name.length + result.indexOf(name)));
 };
 


### PR DESCRIPTION
`array.filter`支持ie9

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter