### PR TITLE
remove content type header for GET to prevent cors problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bay-utils",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "description": "common functions for shanbay frontend projects",
   "main": "lib/index.js",
   "scripts": {

--- a/src/others.js
+++ b/src/others.js
@@ -42,7 +42,6 @@ export const ajax = (options, isOriginal = false, configure) => {
     }, configure);
 
     const defaultOptions = {
-        contentType: 'application/json',
         crossDomain: true,
         xhrFields: {
             withCredentials: true,
@@ -52,6 +51,10 @@ export const ajax = (options, isOriginal = false, configure) => {
             Accept: 'application/json',
         },
     };
+
+    if (options.type !== 'GET') {
+        defaultOptions.contentType = 'application/json';
+    }
 
     const checkAuth = (status) => {
         if (status === 401) {


### PR DESCRIPTION
有时ios webview会出现cors错误，GET request会出现content-type header 不在cors的allow header内。

![screen shot 2018-06-08 at 6 25 55 pm](https://user-images.githubusercontent.com/676478/41153498-66d1ac36-6b49-11e8-8a30-6e2ef0cdf70b.png)


试试给GET去掉content-type header能否解决问题。